### PR TITLE
Update getErrorFlashMessage return type to bool|string

### DIFF
--- a/Classes/Controller/EventController.php
+++ b/Classes/Controller/EventController.php
@@ -216,7 +216,7 @@ class EventController extends ActionController
         return $this->htmlResponse();
     }
 
-    protected function getErrorFlashMessage()
+    protected function getErrorFlashMessage(): bool|string
     {
         return false;
     }


### PR DESCRIPTION
Fix for: https://github.com/BrainAppeal/campus_events_frontend/issues/5
